### PR TITLE
chore(dune): use `ppx_runtime_libraries` stanza for runtime

### DIFF
--- a/js_test/dune
+++ b/js_test/dune
@@ -1,6 +1,5 @@
 (executables
  (names const func)
- (libraries ppx_expjs_runtime)
  (modes js)
  (preprocess
   (pps ppx_expjs)))

--- a/src/dune
+++ b/src/dune
@@ -2,6 +2,7 @@
  (name ppx_expjs)
  (public_name ppx_expjs)
  (kind ppx_rewriter)
+ (ppx_runtime_libraries ppx_expjs_runtime)
  (preprocess
   (pps metaquot.ppx))
- (libraries ppxlib js_of_ocaml ppx_expjs_runtime))
+ (libraries ppxlib js_of_ocaml))


### PR DESCRIPTION
This makes it such that libraries that use the PPX aren't required to explicitly depend on the runtime.